### PR TITLE
QuickUnscale result modifier

### DIFF
--- a/src/parameters/parameters.go
+++ b/src/parameters/parameters.go
@@ -12,4 +12,6 @@ const (
 	Max                              = "max-workers"
 	Override                         = "override"
 	SafeUnscale                      = "safe-unscale"
+	ScaleToZeroIn                    = "scale-to-zero-in"
+	ScaleToMinIn                     = "scale-to-min-in"
 )

--- a/src/strategies/modifiers/quick_unscale.go
+++ b/src/strategies/modifiers/quick_unscale.go
@@ -1,0 +1,70 @@
+package modifiers
+
+import (
+	"github.com/medal-labs/k8s-rmq-autoscaler/base/parameter"
+	"github.com/medal-labs/k8s-rmq-autoscaler/base/scalable"
+	"github.com/medal-labs/k8s-rmq-autoscaler/base/strategy"
+	"github.com/medal-labs/k8s-rmq-autoscaler/parameters"
+	"k8s.io/klog"
+	"time"
+)
+
+var QuickUnscale = strategy.ResultModifier{
+	Name: "quick-unscale",
+	RequiredParameters: map[parameter.Name]strategy.ParameterSpec{
+		parameters.ScaleToZeroIn: {Type: parameter.Duration, DefaultValue: time.Duration(-1)},
+		parameters.ScaleToMinIn:  {Type: parameter.Duration, DefaultValue: time.Duration(-1)},
+		parameters.Min:           {Type: parameter.Int, DefaultValue: -1},
+		parameters.QueueLength:   {Type: parameter.Int},
+	},
+	Execute: func() func(scalable.App, parameter.Values, strategy.Result) (strategy.Result, error) {
+
+		withoutMessagesFrom := map[string]time.Time{}
+
+		return func(app scalable.App, params parameter.Values, prev strategy.Result) (strategy.Result, error) {
+
+			scaleToZeroIn := params.Durations[parameters.ScaleToZeroIn]
+			scaleToMinIn := params.Durations[parameters.ScaleToMinIn]
+			min := params.Ints[parameters.Min]
+
+			if params.Ints[parameters.QueueLength] > 0 {
+				delete(withoutMessagesFrom, app.Key)
+				return prev, nil
+			}
+			appWithoutMessagesFrom, ok := withoutMessagesFrom[app.Key]
+
+			switch {
+			case !ok:
+				withoutMessagesFrom[app.Key] = time.Now()
+				return prev, nil
+			case scaleToZeroIn > 0 && time.Now().Sub(appWithoutMessagesFrom) >= scaleToZeroIn:
+				if klog.V(2) {
+					klog.Infof(
+						"%s's queue has been empty since %s, which is longer than configured 'scale-to-zero-in' duration: %s. Scaling to zero",
+						app.Name, appWithoutMessagesFrom, scaleToZeroIn,
+					)
+				}
+				return strategy.Result{RequiredReplicas: 0}, nil
+			case scaleToMinIn > 0 && time.Now().Sub(appWithoutMessagesFrom) >= scaleToMinIn:
+				if min < 0 {
+					klog.Errorf(
+						"%s's has its scale-to-min duration set without setting min workers, setting min to be 0",
+						app.Name,
+					)
+					min = 0
+				}
+				if prev.RequiredReplicas <= min || app.Replicas <= min && prev.Skip {
+					return prev, nil
+				}
+				if klog.V(2) {
+					klog.Infof(
+						"%s's queue has been empty since %s, which is longer than configured 'scale-to-min-in' duration: %s. Scaling to %d workers",
+						app.Name, appWithoutMessagesFrom, scaleToMinIn, min,
+					)
+				}
+				return strategy.Result{RequiredReplicas: min}, nil
+			}
+			return prev, nil
+		}
+	}(),
+}

--- a/src/strategies/modifiers/safe_unscale.go
+++ b/src/strategies/modifiers/safe_unscale.go
@@ -21,7 +21,7 @@ var SafeUnscale = strategy.ResultModifier{
 		switch {
 		case prev.Skip || !safeUnscale:
 			return prev, nil
-		case prev.RequiredReplicas < app.Replicas && queueLen < 0:
+		case prev.RequiredReplicas < app.Replicas && queueLen > 0:
 			if klog.V(2) {
 				klog.Infof(
 					"Skipping %s downscaling as its queue contains messages and safe unscale is enabled",

--- a/src/strategies/modifiers/steps.go
+++ b/src/strategies/modifiers/steps.go
@@ -39,5 +39,5 @@ var WithSteps = strategy.ResultModifier{
 }
 
 func absLess(a, b int) bool {
-	return math.Abs(float64(a)) < math.Abs(float64(b))
+	return math.Abs(float64(a)) <= math.Abs(float64(b))
 }

--- a/src/strategies/simple.go
+++ b/src/strategies/simple.go
@@ -21,10 +21,11 @@ var SimpleQueueBased = strategy.Config{
 	ResultModifiers: []strategy.ResultModifier{
 		modifiers.WithSteps,
 		modifiers.MinMax,
-		modifiers.SkipUnstable,
-		modifiers.OverrideLimits,
+		modifiers.QuickUnscale,
 		modifiers.SafeUnscale,
+		modifiers.OverrideLimits,
 		modifiers.Cooldown,
+		modifiers.SkipUnstable,
 	},
 	Execute: func(app scalable.App, params parameter.Values) (strategy.Result, error) {
 


### PR DESCRIPTION
`QuickUnscale` result modifier that allows to configure durations after which deployment with empty queue will be downscaled to minimum or zero replicas.

Also contains several quickfixes